### PR TITLE
changing serverspec dependency to greater than or equal to 0.13.5

### DIFF
--- a/ansible_spec.gemspec
+++ b/ansible_spec.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "serverspec", "~> 0.13.5"
+  gem.add_development_dependency "serverspec", ">= 0.13.5"
 
-  gem.add_runtime_dependency "serverspec", "~> 0.13.5"
+  gem.add_runtime_dependency "serverspec", ">= 0.13.5"
 
 end


### PR DESCRIPTION
Serverspec is at 1.0.0 now, ansiblespec-init won't run. I don't know if >= 1.0.0 is ok, but I'm sending a pull request anyways. :)

``` bash
curtis$ ansiblespec-init 
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/dependency.rb:296:in `to_specs': Could not find 'serverspec' (~> 0.13.5) - did find: [serverspec-1.0.0] (Gem::LoadError)
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1196:in `block in activate_dependencies'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1185:in `each'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1185:in `activate_dependencies'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/specification.rb:1167:in `activate'
    from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/rubygems/core_ext/kernel_gem.rb:48:in `gem'
    from /usr/bin/ansiblespec-init:22:in `<main>'
curtis$ gem list | grep serverspec
serverspec (1.0.0)
```
