### PR TITLE
Fix gemspec dpendency

### DIFF
--- a/ansible_spec.gemspec
+++ b/ansible_spec.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "serverspec", ">= 0.13.5"
 
   gem.add_runtime_dependency "serverspec", ">= 0.13.5"
 


### PR DESCRIPTION
I try installing by Bundler. ansible_spec was installed, however serverspec was not  installed. 

``` ruby:Gemfile
  1 source "https://rubygems.org"
  2 gem 'ansible_spec'
```

```
 % bundle install --path vendor/bundle                                                                                     [~/repos/ansible_spec_test]
Fetching gem metadata from https://rubygems.org/..
Resolving dependencies...
Installing ansible_spec 0.0.1.3
Using bundler 1.7.3
Your bundle is complete!
It was installed into ./vendor/bundle
```

```
% ls vendor/bundle/ruby/2.1.0/gems/                                                                                       [~/repos/ansible_spec_test]
ansible_spec-0.0.1.3/
```

This problem is reported RubyGems bug. 
http://d.hatena.ne.jp/tagomoris/20130410/1365586994

If you avoid this problem, you should stop duplicate dependency in 'development_dependency' and 'runtime_dependency'.

``` Gemfile
  1 source "https://rubygems.org"
  2
  3 gem 'ansible_spec',
  4   git: 'https://github.com/Mahito/ansible_spec.git',
  5   branch: 'fix_gemspec_dependency'
```

```
% bundle install --path vendor/bundle                                                                                               [~/repos/ansible_spec_test]
Fetching https://github.com/Mahito/ansible_spec.git
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies...
Installing multi_json 1.10.1
Installing rspec-support 3.1.2
Installing rspec-core 3.1.7
Installing diff-lcs 1.2.5
Installing rspec-expectations 3.1.2
Installing rspec-mocks 3.1.3
Installing rspec 3.1.0
Installing rspec-its 1.0.1
Installing net-ssh 2.9.1
Installing net-scp 1.2.1
Installing specinfra 2.3.0
Installing serverspec 2.3.1
Using ansible_spec 0.0.1.3 from https://github.com/Mahito/ansible_spec.git (at fix_gemspec_dependency)
Using bundler 1.7.3
Your bundle is complete!
It was installed into ./vendor/bundle
```

```
% ls vendor/bundle/ruby/2.1.0/gems/                                                                                                 [~/repos/ansible_spec_test]
ansible_spec-0.0.1.3/     net-scp-1.2.1/            rspec-core-3.1.7/         rspec-mocks-3.1.3/        specinfra-2.3.0/
diff-lcs-1.2.5/           net-ssh-2.9.1/            rspec-expectations-3.1.2/ rspec-support-3.1.2/
multi_json-1.10.1/        rspec-3.1.0/              rspec-its-1.0.1/          serverspec-2.3.1/
```
