### PR TITLE
Handle hosts which are not assigned to any group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ansible_spec.gemspec
 gemspec
+
+if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  # net-ssh 3.x dropped Ruby 1.8 and 1.9 support.
+  gem 'net-ssh', '~> 2.7'
+end

--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -26,22 +26,22 @@ module AnsibleSpec
         next
       end
 
-      #get host
+      # get host
       if group.empty? == false
-        host = Hash.new
-        # 1つのみ、かつ:を含まない場合
-        if line.split.count == 1 && !line.include?(":")
-          # 192.168.0.1
+        if res.has_key?(line)
           res["#{group}"] << line
           next
         elsif line.split.count == 1 && line.include?("[") && line.include?("]")
           # www[01:50].example.com
           # db-[a:f].example.com
           hostlist_expression(line,":").each{|h|
-            res["#{group}"] << h
+            res["#{group}"] << get_inventory_param(h)
           }
           next
         else
+          # 1つのみ、かつ:を含まない場合
+          # 192.168.0.1
+          # 192.168.0.1 ansible_ssh_host=127.0.0.1 ...
           res["#{group}"] << get_inventory_param(line)
           next
         end

--- a/lib/src/Rakefile
+++ b/lib/src/Rakefile
@@ -13,18 +13,12 @@ namespace :serverspec do
       desc "Run serverspec for #{property["name"]}"
       RSpec::Core::RakeTask.new(property["name"].to_sym) do |t|
         puts "Run serverspec for #{property["name"]} to #{host}"
-        if host.instance_of?(Hash)
-          ENV['TARGET_HOST'] = host["uri"]
-          ENV['TARGET_PORT'] = host["port"].to_s
-          ENV['TARGET_PRIVATE_KEY'] = host["private_key"]
-          unless host["user"].nil?
-            ENV['TARGET_USER'] = host["user"]
-          else
-            ENV['TARGET_USER'] = property["user"]
-          end
+        ENV['TARGET_HOST'] = host["uri"]
+        ENV['TARGET_PORT'] = host["port"].to_s
+        ENV['TARGET_PRIVATE_KEY'] = host["private_key"]
+        unless host["user"].nil?
+          ENV['TARGET_USER'] = host["user"]
         else
-          ENV['TARGET_HOST'] = host
-          ENV['TARGET_PRIVATE_KEY'] = '~/.ssh/id_rsa'
           ENV['TARGET_USER'] = property["user"]
         end
         t.pattern = 'roles/{' + property["roles"].join(',') + '}/spec/*_spec.rb'

--- a/spec/inventory_parameters_spec.rb
+++ b/spec/inventory_parameters_spec.rb
@@ -29,6 +29,8 @@ EOF
 EOF
 
   content_h = <<'EOF'
+node ansible_ssh_port=4444 ansible_ssh_host=192.168.1.55
+
 [normal]
 192.168.0.1
 192.168.0.2 ansible_ssh_port=22
@@ -36,8 +38,9 @@ EOF
 192.168.0.4 ansible_ssh_private_key_file=~/.ssh/id_rsa
 192.168.0.5 ansible_ssh_user=git
 jumper ansible_ssh_port=5555 ansible_ssh_host=192.168.1.50
-
+node
 EOF
+
   create_file(tmp_ansiblespec,content)
   create_file(tmp_playbook,content_p)
   create_file(tmp_hosts,content_h)
@@ -103,6 +106,14 @@ describe "load_targetsの実行" do
       expect(obj['name']).to eq 'jumper ansible_ssh_port=5555 ansible_ssh_host=192.168.1.50'
       expect(obj['uri']).to eq '192.168.1.50'
       expect(obj['port']).to eq 5555
+    end
+
+    it 'node ansible_ssh_port=4444 ansible_ssh_host=192.168.1.55' do
+      obj = @res['normal'][6]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj['name']).to eq 'node ansible_ssh_port=4444 ansible_ssh_host=192.168.1.55'
+      expect(obj['uri']).to eq '192.168.1.55'
+      expect(obj['port']).to eq 4444
     end
 
     after do

--- a/spec/inventory_parameters_spec.rb
+++ b/spec/inventory_parameters_spec.rb
@@ -65,8 +65,9 @@ describe "load_targetsの実行" do
 
     it 'normal 192.168.0.1' do
       obj = @res['normal'][0]
-      expect(obj.instance_of?(String)).to be_truthy
-      expect(obj).to eq '192.168.0.1'
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj['uri']).to eq '192.168.0.1'
+      expect(obj['port']).to eq 22
     end
     it 'normal 192.168.0.2 ansible_ssh_port=22' do
       obj = @res['normal'][1]
@@ -141,7 +142,9 @@ describe "get_propertiesの実行" do
 
     it 'normal 192.168.0.1' do
       expect(@res[0]['hosts'].instance_of?(Array)).to be_truthy
-      expect(@res[0]['hosts'][0]).to eq '192.168.0.1'
+      expect(@res[0]['hosts'][0]).to include({'name' => '192.168.0.1',
+                                              'uri' => '192.168.0.1',
+                                              'port' => 22})
     end
 
     it 'normal 192.168.0.2 ansible_ssh_port=22' do

--- a/spec/load_ansible_spec.rb
+++ b/spec/load_ansible_spec.rb
@@ -35,13 +35,19 @@ EOF
     end
 
     it 'exist 1st server' do
-      expect(@res['server'][0]).to eq '192.168.0.1'
+      expect(@res['server'][0]).to include({'uri' => '192.168.0.1',
+                                            'name' => '192.168.0.1',
+                                            'port' => 22})
     end
     it 'exist 2nd server' do
-      expect(@res['server'][1]).to eq '192.168.0.2'
+      expect(@res['server'][1]).to include({'uri' => '192.168.0.2',
+                                            'name' => '192.168.0.2',
+                                            'port' => 22})
     end
     it 'exist 3rd server' do
-      expect(@res['server'][2]).to eq 'example.com'
+      expect(@res['server'][2]).to include({'uri' => 'example.com',
+                                            'name' => 'example.com',
+                                            'port' => 22})
     end
     it 'not exist 4th server' do
       expect(@res['server'][3]).to eq nil
@@ -82,10 +88,14 @@ EOF
       expect(@res.key?('web')).to be_truthy
     end
     it 'exist 1st web' do
-      expect(@res['web'][0]).to eq '192.168.0.3'
+      expect(@res['web'][0]).to include({'name' => '192.168.0.3',
+                                         'uri' => '192.168.0.3',
+                                         'port' => 22})
     end
     it 'exist 2nd web' do
-      expect(@res['web'][1]).to eq '192.168.0.4'
+      expect(@res['web'][1]).to include({'name' => '192.168.0.4',
+                                         'uri' => '192.168.0.4',
+                                         'port' => 22})
     end
     it 'not exist 3rd web' do
       expect(@res['web'][2]).to eq nil
@@ -96,10 +106,14 @@ EOF
       expect(@res.key?('db')).to be_truthy
     end
     it 'exist 1st db' do
-      expect(@res['db'][0]).to eq '192.168.0.5'
+      expect(@res['db'][0]).to include({'name' => '192.168.0.5',
+                                        'uri' => '192.168.0.5',
+                                        'port' => 22})
     end
     it 'exist 2nd db' do
-      expect(@res['db'][1]).to eq '192.168.0.6'
+      expect(@res['db'][1]).to include({'name' => '192.168.0.6',
+                                        'uri' => '192.168.0.6',
+                                        'port' => 22})
     end
     it 'not exist 3rd db' do
       expect(@res['db'][2]).to eq nil
@@ -139,14 +153,18 @@ EOF
     it 'www[01:50].example.com' do
       1.upto(50){|n|
         leading_zero = n.to_s.rjust(2, '0')
-        expect(@res['web']["#{n - 1}".to_i]).to eq "www#{leading_zero}.example.com"
+        expect(@res['web']["#{n - 1}".to_i]).to include({'name' => "www#{leading_zero}.example.com",
+                                                         'uri' => "www#{leading_zero}.example.com",
+                                                         'port' => 22})
       }
     end
 
     it 'db-[a:f].example.com' do
       alphabet = [*'a'..'f'] # Array splat
       alphabet.each_with_index {|word, i|
-        expect(@res['databases'][i]).to eq "db-#{word}.example.com"
+        expect(@res['databases'][i]).to include ({'name' => "db-#{word}.example.com",
+                                                  'uri' => "db-#{word}.example.com",
+                                                  'port' => 22})
       }
     end
 
@@ -241,7 +259,9 @@ EOF
       expect(@res['server'][0]).not_to eq '192.168.0.10'
     end
     it 'exist 2nd server' do
-      expect(@res['server'][0]).to eq '192.168.0.11'
+      expect(@res['server'][0]).to include({'name' => '192.168.0.11',
+                                            'uri' => '192.168.0.11',
+                                            'port' => 22})
     end
 
     after do
@@ -275,10 +295,14 @@ EOF
       expect(@res.key?('web')).to be_truthy
     end
     it 'exist 1st web' do
-      expect(@res['web'][0]).to eq '192.168.0.3'
+      expect(@res['web'][0]).to include ({'name' => '192.168.0.3',
+                                          'uri' => '192.168.0.3',
+                                          'port' => 22})
     end
     it 'exist 2nd web' do
-      expect(@res['web'][1]).to eq '192.168.0.4'
+      expect(@res['web'][1]).to include ({'name' => '192.168.0.4',
+                                          'uri' => '192.168.0.4',
+                                          'port' => 22})
     end
 
     after do
@@ -323,8 +347,10 @@ EOF
 
     it 'pg 192.168.0.103' do
       obj = @res['pg'][0]
-      expect(obj.instance_of?(String)).to be_truthy
-      expect(obj).to eq '192.168.0.103'
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj).to include({'name' => '192.168.0.103',
+                              'uri' => '192.168.0.103',
+                              'port' => 22})
     end
 
     it 'pg 192.168.0.104 ansible_ssh_port=22' do
@@ -337,8 +363,10 @@ EOF
 
     it 'pg 192.168.0.105' do
       obj = @res['pg'][2]
-      expect(obj.instance_of?(String)).to be_truthy
-      expect(obj).to eq '192.168.0.105'
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj).to include({'name' => '192.168.0.105',
+                              'uri' => '192.168.0.105',
+                              'port' => 22})
     end
 
     it 'pg 192.168.0.106 ansible_ssh_port=5555' do
@@ -1156,8 +1184,12 @@ EOF
 
     it 'exist hosts' do
       expect(@res[0]['hosts'].instance_of?(Array)).to be_truthy
-      expect(@res[0]['hosts'][0]).to eq '192.168.0.103'
-      expect(@res[0]['hosts'][1]).to eq '192.168.0.104'
+      expect(@res[0]['hosts'][0]).to include({'name' => '192.168.0.103',
+                                              'uri' => '192.168.0.103',
+                                              'port' => 22})
+      expect(@res[0]['hosts'][1]).to include({'name' => '192.168.0.104',
+                                              'uri' => '192.168.0.104',
+                                              'port' => 22})
     end
 
     it 'exist user' do
@@ -1237,7 +1269,18 @@ EOF
 
     it 'exist hosts' do
       expect(@res[0]['hosts'].instance_of?(Array)).to be_truthy
-      expect(['192.168.0.103','192.168.0.104','192.168.0.105','192.168.0.106']).to match_array(@res[0]['hosts'])
+      expect([{'name' => '192.168.0.103',
+               'uri' => '192.168.0.103',
+               'port' => 22},
+              {'name' => '192.168.0.104',
+               'uri' => '192.168.0.104',
+               'port' => 22},
+              {'name' => '192.168.0.105',
+               'uri' => '192.168.0.105',
+               'port' => 22},
+              {'name' => '192.168.0.106',
+               'uri' => '192.168.0.106',
+               'port' => 22}]).to match_array(@res[0]['hosts'])
     end
 
     it 'exist user' do

--- a/spec/load_ansible_spec.rb
+++ b/spec/load_ansible_spec.rb
@@ -128,10 +128,14 @@ EOF
     tmp_hosts = 'hosts'
     before do
       content = <<'EOF'
+node[01:20] ansible_ssh_port=2222
+
 [web]
 www[01:50].example.com
 [databases]
 db-[a:f].example.com
+[nodes]
+node[01:20]
 EOF
       create_file(tmp_hosts,content)
       @res = AnsibleSpec.load_targets(tmp_hosts)
@@ -142,7 +146,7 @@ EOF
     end
 
     it 'check 1 group' do
-      expect(@res.length).to eq 2
+      expect(@res.length).to eq 3
     end
 
     it 'check group name' do
@@ -165,6 +169,15 @@ EOF
         expect(@res['databases'][i]).to include ({'name' => "db-#{word}.example.com",
                                                   'uri' => "db-#{word}.example.com",
                                                   'port' => 22})
+      }
+    end
+
+    it 'node[01:20]' do
+      1.upto(20){|n|
+        leading_zero = n.to_s.rjust(2, '0')
+        expect(@res['nodes']["#{n - 1}".to_i]).to include({'name' => "node#{leading_zero} ansible_ssh_port=2222",
+                                                           'uri' => "node#{leading_zero}",
+                                                           'port' => 2222})
       }
     end
 


### PR DESCRIPTION
Example inventory file, which is currently not parsed correctly:

```
# Generated by Vagrant

node1 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2222 ansible_ssh_private_key_file=/Users/gerrrr/project/.vagrant/machines/node1/virtualbox/private_key
node2 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2200 ansible_ssh_private_key_file=/Users/gerrrr/project/.vagrant/machines/node2/virtualbox/private_key
node3 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2201 ansible_ssh_private_key_file=/Users/gerrrr/project/.vagrant/machines/node3/virtualbox/private_key
node4 ansible_ssh_host=127.0.0.1 ansible_ssh_port=2202 ansible_ssh_private_key_file=/Users/gerrrr/project/.vagrant/machines/node4/virtualbox/private_key

[group1]
node1

[group2]
node1
node2
node3
node4

[group3]
node2
node3
node4
```

This PR solves the problem by keeping track of host definitions outside of group statements.
