### PR TITLE
Removed trailing whitespace from generated files

### DIFF
--- a/lib/src/.ansiblespec
+++ b/lib/src/.ansiblespec
@@ -1,4 +1,4 @@
---- 
-- 
+---
+-
   playbook: site.yml
   inventory: hosts


### PR DESCRIPTION
Trivial fix to remove trailing whitespace from ansiblespec-init generated files. This is generally accepted best practice and checked in ansible-lint. 