### PR TITLE
Bugs in inventory parsing

### DIFF
--- a/spec/load_ansible_spec.rb
+++ b/spec/load_ansible_spec.rb
@@ -421,7 +421,32 @@ EOF
     after do
       File.delete(tmp_hosts)
     end
+  end
 
+  context 'Nested groups' do
+    tmp_hosts = 'hosts'
+    before do
+      content_h = <<'EOF'
+[child]
+192.168.0.1
+
+[parent:children]
+child
+
+[grandparent:children]
+parent
+EOF
+      create_file(tmp_hosts,content_h)
+      @res = AnsibleSpec.load_targets(tmp_hosts)
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    after do
+      File.delete(tmp_hosts)
+    end
   end
 
 end

--- a/spec/load_ansible_spec.rb
+++ b/spec/load_ansible_spec.rb
@@ -400,6 +400,30 @@ EOF
     end
   end
 
+  context 'Group before children' do
+    tmp_hosts = 'hosts'
+    before do
+      content_h = <<'EOF'
+[group:children]
+child
+
+[child]
+192.168.0.103
+EOF
+      create_file(tmp_hosts,content_h)
+      @res = AnsibleSpec.load_targets(tmp_hosts)
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    after do
+      File.delete(tmp_hosts)
+    end
+
+  end
+
 end
 
 describe "load_playbookの実行" do


### PR DESCRIPTION
There's a bug in the inventory parsing code. It assumes that the group comes after the child, which is not required in ansible.

Stack trace when calling AnsibleSpec.get_properties:

```
TypeError: no implicit conversion of nil into Array
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:92:in `+'
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:92:in `block in get_parent'
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:91:in `each'
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:91:in `get_parent'
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:72:in `block in load_targets'
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:67:in `each'
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:67:in `load_targets'
ansible_spec-0.2.8/lib/ansible_spec/load_ansible.rb:282:in `get_properties'
```

I have submitted a test case to demonstrate this bug, however I'm unsure how to fix/address.
