### PR TITLE
return an empty array when the group has no hosts in it

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -273,8 +273,7 @@ module AnsibleSpec
   def self.get_properties()
     playbook, inventoryfile = load_ansiblespec
 
-    #load inventry file
-    # inventory fileとplaybookのhostsをマッピングする。
+    # load inventory file and playbook hosts mapping
     hosts = load_targets(inventoryfile)
     properties = load_playbook(playbook)
     properties.each do |var|
@@ -285,6 +284,7 @@ module AnsibleSpec
         var["hosts"] = hosts["#{var["hosts"]}"]
       else
         puts "no hosts matched for #{var["hosts"]}"
+        var["hosts"] = []
       end
     end
     return properties


### PR DESCRIPTION
### Description

This makes the "get_properties" always return an array. Currently, it usually returns an array but might return the same string (when not found), which is a bit uncomfortable to work with from the user's pov. Furthermore, this allows to easily iterate over the hosts, because even if the group is empty (because, for example, a given environment has no hosts of that group, which only exists in other environments).


### How to test/reproduce
I wrote a trivial Gemfile based on the https://github.com/volanja/ansible-sample-tdd code:
```
source 'https://rubygems.org'
gem 'ansible_spec', :git => 'https://github.com/franmrl/ansible_spec.git'
```
Change in site.yml so you define a non existing group (like, change server to servers).
Then run
````
bundle
rake serverspec:Ansible-Sample-TDD
```

It will fail to build the task instead of getting a weird `NoMethodError: undefined method 'each' for "servers":String` error.