### PR TITLE
Support the Windows as target host OS

### DIFF
--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -1,46 +1,93 @@
 require 'serverspec'
 require 'net/ssh'
 require 'ansible_spec'
-
-set :backend, :ssh
-
-if ENV['ASK_SUDO_PASSWORD']
-  begin
-    require 'highline/import'
-  rescue LoadError
-    fail "highline is not available. Try installing it."
-  end
-  set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
-else
-  set :sudo_password, ENV['SUDO_PASSWORD']
-end
-
-host = ENV['TARGET_HOST']
-
-options = Net::SSH::Config.for(host)
-
-options[:user] ||= ENV['TARGET_USER']
-options[:port] ||= ENV['TARGET_PORT']
-options[:keys] ||= ENV['TARGET_PRIVATE_KEY']
-
-set :host,        options[:host_name] || host
-set :ssh_options, options
-
-# Disable sudo
-# set :disable_sudo, true
-
-
-# Set environment variables
-# set :env, :LANG => 'C', :LC_MESSAGES => 'C'
-
-# Set PATH
-# set :path, '/sbin:/usr/local/sbin:$PATH'
+require 'winrm'
 
 #
 # Set ansible variables to serverspec property
 #
+host = ENV['TARGET_HOST']
 
 group_idx = ENV['TARGET_GROUP_INDEX'].to_i
-
 vars = AnsibleSpec.get_variables(host, group_idx)
 set_property vars
+
+user = property['ansible_ssh_user'] || property['ansible_user'] || ENV['TARGET_USER']
+port = property['ansible_ssh_port'] || property['ansible_port'] || ENV['TARGET_PORT']
+keys = property['ansible_ssh_private_key_file'] || property['ansible_private_key_file'] || ENV['TARGET_PRIVATE_KEY']
+
+# !Note: This pass variable will be used only to WinRM connection
+pass ||= property['ansible_ssh_pass'] || property['ansible_password'] || ENV['TARGET_PASSWORD']
+
+p "d1:user:#{user} ,ansible_user: #{property['ansible_user']}, ansible_ssh_user: #{property['ansible_ssh_user']}\n"
+p "d2:port:#{port} ,ansible_ssh_port: #{property['ansible_ssh_port']}, ansible_port: #{property['ansible_port']}\n"
+p "d3:keys:#{keys} ,ansible_ssh_private_key_file: #{property['ansible_ssh_private_key_file']}, ansible_private_key_file: #{property['ansible_private_key_file']}\n"
+p "d4:pass:#{pass} ,ansible_ssh_pass: #{property['ansible_ssh_pass']}, ansible_password: #{property['ansible_password']}\n"
+
+if property['ansible_connection'] != 'winrm'
+#
+# In the case of the unix system. 
+#
+  set :backend, :ssh
+  set :request_pty, true
+
+  if ENV['ASK_SUDO_PASSWORD']
+    begin
+      require 'highline/import'
+    rescue LoadError
+      fail "highline is not available. Try installing it."
+    end
+    set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
+  else
+    set :sudo_password, ENV['SUDO_PASSWORD']
+  end
+
+  options = Net::SSH::Config.for(host)
+
+  options[:user] ||= user
+  options[:port] ||= port
+  options[:keys] ||= keys
+
+  set :host,        options[:host_name] || host
+  set :ssh_options, options
+
+  # Disable sudo
+  # set :disable_sudo, true
+
+
+  # Set environment variables
+  # set :env, :LANG => 'C', :LC_MESSAGES => 'C'
+
+  # Set PATH
+  # set :path, '/sbin:/usr/local/sbin:$PATH'
+
+else
+#
+# In the case of the windows system. 
+#
+  set :backend, :winrm
+  set :os, :family => 'windows'
+
+  if user.nil?
+    begin
+      require 'highline/import'
+    rescue LoadError
+      fail "highline is not available. Try installing it."
+    end
+    user = ask("\nEnter #{host}'s login user: ") { |q| q.echo = true }
+  end
+  if pass.nil?
+    begin
+      require 'highline/import'
+    rescue LoadError
+      fail "highline is not available. Try installing it."
+    end
+    pass = ask("\nEnter #{user}@#{host}'s login password: ") { |q| q.echo = false }
+  end
+
+  endpoint = "http://#{host}:#{port}/wsman"
+
+  winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
+  winrm.set_timeout 300 # 5 minutes max timeout for any operation
+  Specinfra.configuration.winrm = winrm
+end

--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -19,11 +19,6 @@ keys = property['ansible_ssh_private_key_file'] || property['ansible_private_key
 # !Note: This pass variable will be used only to WinRM connection
 pass ||= property['ansible_ssh_pass'] || property['ansible_password'] || ENV['TARGET_PASSWORD']
 
-p "d1:user:#{user} ,ansible_user: #{property['ansible_user']}, ansible_ssh_user: #{property['ansible_ssh_user']}\n"
-p "d2:port:#{port} ,ansible_ssh_port: #{property['ansible_ssh_port']}, ansible_port: #{property['ansible_port']}\n"
-p "d3:keys:#{keys} ,ansible_ssh_private_key_file: #{property['ansible_ssh_private_key_file']}, ansible_private_key_file: #{property['ansible_private_key_file']}\n"
-p "d4:pass:#{pass} ,ansible_ssh_pass: #{property['ansible_ssh_pass']}, ansible_password: #{property['ansible_password']}\n"
-
 if property['ansible_connection'] != 'winrm'
 #
 # In the case of the unix system. 


### PR DESCRIPTION
##### This pull request Overview
I changed the ansible_spec's spec_helper.rb as follows.
+ Support the Windows as the target host OS.
+ Support  the Ansible's new style variables ( ansible_user, port, password, private_key_file) in target host connection.

###### Note
##### Common
 + Ansible's  new style target host variables(`ansible_user, port, password, private_key_file`) , please set at the `group_vars/` or `host_vars/`.  [`ansible_ssh_*` is older style variables.](http://docs.ansible.com/ansible/intro_inventory.html)
 + `ansible_password` variable will be used only to WinRM connection.

##### Windows
 + If you want to use the Windows OS ,please set the follows variables  at the  `group_vars/` or `host_vars/`.

```
ansible_port: 5985 # or 5986
ansible_connection: winrm
```

   + If the following values are not set enter at the time of run.
```
ansible_user:
ansible_password:
```