### PR TITLE
Support Windows

### DIFF
--- a/ansible_spec.gemspec
+++ b/ansible_spec.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "serverspec", ">= 2.0.0"
   gem.add_runtime_dependency "hostlist_expression"
   gem.add_runtime_dependency "oj"
+  gem.add_runtime_dependency "winrm"
 
 end

--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -148,6 +148,8 @@ module AnsibleSpec
         host['private_key'] = value if key == "ansible_ssh_private_key_file"
         host['user'] = value if key == "ansible_ssh_user"
         host['uri'] = value if key == "ansible_ssh_host"
+        host['pass'] = value if key == "ansible_ssh_pass"
+        host['conn'] = value if key == "ansible_connection"
       end
     }
     return host

--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -149,7 +149,7 @@ module AnsibleSpec
         host['user'] = value if key == "ansible_ssh_user"
         host['uri'] = value if key == "ansible_ssh_host"
         host['pass'] = value if key == "ansible_ssh_pass"
-        host['conn'] = value if key == "ansible_connection"
+        host['connection'] = value if key == "ansible_connection"
       end
     }
     return host

--- a/lib/src/Rakefile
+++ b/lib/src/Rakefile
@@ -23,7 +23,7 @@ namespace :serverspec do
           ENV['TARGET_USER'] = property["user"]
         end
         ENV['TARGET_PASSWORD'] = host["pass"]
-        ENV['TARGET_CONNECTION'] = host["conn"]
+        ENV['TARGET_CONNECTION'] = host["connection"]
 
         roles = property["roles"]
         for role in property["roles"]

--- a/lib/src/Rakefile
+++ b/lib/src/Rakefile
@@ -22,6 +22,8 @@ namespace :serverspec do
         else
           ENV['TARGET_USER'] = property["user"]
         end
+        ENV['TARGET_PASSWORD'] = host["pass"]
+        ENV['TARGET_CONNECTION'] = host["conn"]
 
         roles = property["roles"]
         for role in property["roles"]

--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -12,9 +12,9 @@ group_idx = ENV['TARGET_GROUP_INDEX'].to_i
 vars = AnsibleSpec.get_variables(host, group_idx)
 set_property vars
 
-conn = ENV['TARGET_CONNECTION']
+connection = ENV['TARGET_CONNECTION']
 
-if conn != 'winrm'
+if connection != 'winrm'
 #
 # OS type: UN*X
 #

--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -1,46 +1,88 @@
 require 'serverspec'
 require 'net/ssh'
 require 'ansible_spec'
+require 'winrm'
 
-set :backend, :ssh
+conn = ENV['TARGET_CONNECTION']
 
-if ENV['ASK_SUDO_PASSWORD']
-  begin
-    require 'highline/import'
-  rescue LoadError
-    fail "highline is not available. Try installing it."
+if conn != 'winrm'
+#
+# OS type: UN*X
+#
+  set :backend, :ssh
+
+  if ENV['ASK_SUDO_PASSWORD']
+    begin
+      require 'highline/import'
+    rescue LoadError
+      fail "highline is not available. Try installing it."
+    end
+    set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
+  else
+    set :sudo_password, ENV['SUDO_PASSWORD']
   end
-  set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
+
+  host = ENV['TARGET_HOST']
+
+  options = Net::SSH::Config.for(host)
+
+  options[:user] ||= ENV['TARGET_USER']
+  options[:port] ||= ENV['TARGET_PORT']
+  options[:keys] ||= ENV['TARGET_PRIVATE_KEY']
+
+  set :host,        options[:host_name] || host
+  set :ssh_options, options
+
+  # Disable sudo
+  # set :disable_sudo, true
+
+
+  # Set environment variables
+  # set :env, :LANG => 'C', :LC_MESSAGES => 'C'
+
+  # Set PATH
+  # set :path, '/sbin:/usr/local/sbin:$PATH'
 else
-  set :sudo_password, ENV['SUDO_PASSWORD']
+#
+# OS type: Windows
+#
+  set :backend, :winrm
+  set :os, :family => 'windows'
+
+  user = ENV['TARGET_USER']
+  port = ENV['TARGET_PORT']
+  pass = ENV['TARGET_PASSWORD']
+
+  if user.nil?
+    begin
+      require 'highline/import'
+    rescue LoadError
+      fail "highline is not available. Try installing it."
+    end
+    user = ask("\nEnter #{host}'s login user: ") { |q| q.echo = true }
+  end
+  if pass.nil?
+    begin
+      require 'highline/import'
+    rescue LoadError
+      fail "highline is not available. Try installing it."
+    end
+    pass = ask("\nEnter #{user}@#{host}'s login password: ") { |q| q.echo = false }
+  end
+
+  endpoint = "http://#{host}:#{port}/wsman"
+
+  winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => user, :pass => pass, :basic_auth_only => true)
+  winrm.set_timeout 300 # 5 minutes max timeout for any operation
+  Specinfra.configuration.winrm = winrm
+
 end
-
-host = ENV['TARGET_HOST']
-
-options = Net::SSH::Config.for(host)
-
-options[:user] ||= ENV['TARGET_USER']
-options[:port] ||= ENV['TARGET_PORT']
-options[:keys] ||= ENV['TARGET_PRIVATE_KEY']
-
-set :host,        options[:host_name] || host
-set :ssh_options, options
-
-# Disable sudo
-# set :disable_sudo, true
-
-
-# Set environment variables
-# set :env, :LANG => 'C', :LC_MESSAGES => 'C'
-
-# Set PATH
-# set :path, '/sbin:/usr/local/sbin:$PATH'
 
 #
 # Set ansible variables to serverspec property
 #
+host = ENV['TARGET_HOST']
 
 group_idx = ENV['TARGET_GROUP_INDEX'].to_i
-
 vars = AnsibleSpec.get_variables(host, group_idx)
 set_property vars

--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -3,6 +3,15 @@ require 'net/ssh'
 require 'ansible_spec'
 require 'winrm'
 
+#
+# Set ansible variables to serverspec property
+#
+host = ENV['TARGET_HOST']
+
+group_idx = ENV['TARGET_GROUP_INDEX'].to_i
+vars = AnsibleSpec.get_variables(host, group_idx)
+set_property vars
+
 conn = ENV['TARGET_CONNECTION']
 
 if conn != 'winrm'
@@ -21,8 +30,6 @@ if conn != 'winrm'
   else
     set :sudo_password, ENV['SUDO_PASSWORD']
   end
-
-  host = ENV['TARGET_HOST']
 
   options = Net::SSH::Config.for(host)
 
@@ -77,12 +84,3 @@ else
   Specinfra.configuration.winrm = winrm
 
 end
-
-#
-# Set ansible variables to serverspec property
-#
-host = ENV['TARGET_HOST']
-
-group_idx = ENV['TARGET_GROUP_INDEX'].to_i
-vars = AnsibleSpec.get_variables(host, group_idx)
-set_property vars


### PR DESCRIPTION
##### This pull request is what was cut the following than #67 
+ Support Windows

##### If you want to use the Windows OS as target host.
+ Please set the inventory file the UN*X host as well as the following connection variables.

``` 
# ex.) Windows
192.168.1.3 ansible_connection=winrm ansible_ssh_port=5985 ansible_ssh_user=administrator ansible_ssh_password=Passw0rd
```
+ The following variables are required.
  + `ansible_connection`
  + `ansible_ssh_port`

+ The following variables are input at the run if not set.
  + `ansible_ssh_user`
  + `ansible_ssh_password`

##### Note
+ `ansible_ssh_password`  variable will be used only to WinRM connection.