### PR TITLE
Read inventory from python ansible

### DIFF
--- a/ansible_spec.gemspec
+++ b/ansible_spec.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "serverspec", ">= 2.0.0"
   gem.add_runtime_dependency "hostlist_expression"
   gem.add_runtime_dependency "oj"
+  gem.add_runtime_dependency "rubypython"
 
 end

--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -268,6 +268,20 @@ module AnsibleSpec
     end
   end
 
+  def self.get_inventory()
+    playbook, inventoryfile = load_ansiblespec
+
+    require 'rubypython'
+    RubyPython.start
+    sys = RubyPython.import('sys')
+    sys.path.append(File.dirname(__FILE__) + "/../py")
+    py_ansible_spec = RubyPython.import('ansible_spec')
+
+    inventory = py_ansible_spec.load_ansible(inventoryfile)
+
+    return inventory
+  end
+
   # return: json
   # {"name"=>"Ansible-Sample-TDD", "hosts"=>["192.168.0.103"], "user"=>"root", "roles"=>["nginx", "mariadb"]}
   def self.get_properties()

--- a/lib/py/ansible_spec.py
+++ b/lib/py/ansible_spec.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+
+import ansible
+
+def load_ansible(inv_file):
+    inventory = None
+    if ansible.__version__.startswith('1.'):
+        from ansible.inventory import Inventory
+
+        inventory = Inventory(inv_file)
+
+    elif ansible.__version__.startswith('2.'):
+        from ansible.inventory import Inventory
+        from ansible.parsing.dataloader import DataLoader
+        from ansible.vars import VariableManager
+
+        loader = DataLoader()
+        variable_manager = VariableManager()
+        inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=inv_file)
+
+    else:
+        raise "Unsupported ansible version"
+
+    return inventory


### PR DESCRIPTION
Continuing from the #62 discussion: a better way to process ansible config would be to hook into the python ansible modules. This is currently a proof of concept as it would require a large rewrite of the internal state/load_ansible and deserves a bigger discussion/community input. Additionally this could be extended to parse/process playbooks.

sample inventory

```
[child]
192.168.0.1
[parent]
192.168.50.1
[grandparent]
192.168.100.1
[parent:children]
child
[grandparent:children]
parent
```

test.rb

``` ruby
require 'ansible_spec'
inv = AnsibleSpec.get_inventory()

inv.get_hosts.to_enum.each do |host|
  puts "host: #{host} = #{host.get_vars}"
end

inv.get_groups.to_enum.each do |group|
  puts "group: #{group}, #{inv.get_hosts(group)}"
end
```

Output

```
$ ruby test.rb
host: 192.168.0.1 = {'inventory_hostname': u'192.168.0.1', 'group_names': [u'child', u'grandparent', u'parent'], 'inventory_hostname_short': u'192'}
host: 192.168.50.1 = {'inventory_hostname': u'192.168.50.1', 'group_names': [u'grandparent', u'parent'], 'inventory_hostname_short': u'192'}
host: 192.168.100.1 = {'inventory_hostname': u'192.168.100.1', 'group_names': [u'grandparent'], 'inventory_hostname_short': u'192'}
group: ungrouped, []
group: grandparent, [192.168.0.1, 192.168.50.1, 192.168.100.1]
group: all, [192.168.0.1, 192.168.50.1, 192.168.100.1]
group: parent, [192.168.0.1, 192.168.50.1]
group: child, [192.168.0.1]
```
