### PR TITLE
Add inventory vars to get_variables method

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -305,6 +305,35 @@ module AnsibleSpec
       end
     end
 
+    # inventory vars
+    vars_file = File.dirname(inventoryfile)+"/group_vars/all"
+    if File.exist?(vars_file)
+      yaml = YAML.load_file(vars_file)
+      if yaml.kind_of?(Hash)
+        vars.merge!(yaml)
+      end
+    end
+
+    # inventory group vars
+    if p[group_idx].has_key?('group')
+      vars_file = File.dirname(inventoryfile)+"/group_vars/#{p[group_idx]['group']}.yml"
+      if File.exist?(vars_file)
+        yaml = YAML.load_file(vars_file)
+        if yaml.kind_of?(Hash)
+          vars.merge!(yaml)
+        end
+      end
+    end
+
+    # inventory host vars
+    vars_file = File.dirname(inventoryfile)+"/host_vars/#{host}.yml"
+    if File.exist?(vars_file)
+      yaml = YAML.load_file(vars_file)
+      if yaml.kind_of?(Hash)
+        vars.merge!(yaml)
+      end
+    end
+
     # all group
     vars_file = 'group_vars/all.yml'
     if File.exist?(vars_file)

--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -291,6 +291,7 @@ module AnsibleSpec
   end
 
   def self.get_variables(host, group_idx)
+    playbook, inventoryfile = load_ansiblespec
     vars = {}
     p = self.get_properties
 


### PR DESCRIPTION
Create a PR to improve get_variables method according this order allowing to get inventory vars:
In 2.x, we have made the order of precedence more specific (with the last listed variables winning prioritization):
- [ ]  role defaults 
- [X] **_inventory vars**_
- [X] **_inventory group_vars**_
- [X] **_inventory host_vars**_
- [ ]  playbook group_vars
- [ ]  playbook host_vars
- [ ]  host facts
- [ ]  registered vars
- [ ]  set_facts
- [ ]  play vars
- [ ]  play vars_prompt
- [ ]  play vars_files
- [ ]  role and include vars
- [ ]  block vars (only for tasks in block)
- [ ]  task vars (only for the task)
- [ ]  extra vars (always win precedence)

REF: http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable
