### PR TITLE
Handle "simple" role dependencies

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -204,7 +204,7 @@ module AnsibleSpec
 
       if File.exist?(path)
         new_deps = YAML.load_file(path).fetch("dependencies", []).map { |h|
-          h["role"]
+          h["role"] || h
         }
         role_queue.concat(new_deps)
         deps.concat(new_deps)

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -35,7 +35,7 @@ EOF
 ---
 dependencies:
 - { role: dep1 }
-- { role: dep2 }
+- dep2
 EOF
 
   dep1_meta_content = <<'EOF'


### PR DESCRIPTION
Dependencies can be

  dependencies:
    - <rolename>

or

  dependencies:
    - { role: <rolename> }

Handle both.
