### PR TITLE
fix nil dependencies

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -203,11 +203,14 @@ module AnsibleSpec
       path = File.join("./", "roles", role, "meta", "main.yml")
 
       if File.exist?(path)
-        new_deps = YAML.load_file(path).fetch("dependencies", []).map { |h|
-          h["role"]
-        }
-        role_queue.concat(new_deps)
-        deps.concat(new_deps)
+        dependencies = YAML.load_file(path).fetch("dependencies", [])
+        unless dependencies.nil? 
+          new_deps = dependencies.map { |h|
+            h["role"]
+          }
+          role_queue.concat(new_deps)
+          deps.concat(new_deps)
+        end
       end
     end
     return deps


### PR DESCRIPTION
currently the ansible_spec fails with an error if the role has a dependencies list that is empty as it evaluates to nil. This PR will fix this by checking for nil before running it.
