### PR TITLE
set a option, it can select file of SSH-configration

### DIFF
--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -32,7 +32,11 @@ if connection != 'winrm'
     set :sudo_password, ENV['SUDO_PASSWORD']
   end
 
-  options = Net::SSH::Config.for(host)
+  unless ENV['SSH_CONFIG_FILE']
+    options = Net::SSH::Config.for(host)
+  else
+    options = Net::SSH::Config.for(host, files=[ENV['SSH_CONFIG_FILE']])
+  end
 
   options[:user] ||= ENV['TARGET_USER']
   options[:port] ||= ENV['TARGET_PORT']


### PR DESCRIPTION
`$ rake all SSH_CONFIG_FILE="~/.ssh/ecs_ssh_config"`
としてSSHの設定を指定できる。
（ansible.cfgでssh_argsに指定するファイルにしたかったため）