### PR TITLE
Parse roledirs from ansible.cfg

### DIFF
--- a/ansible_spec.gemspec
+++ b/ansible_spec.gemspec
@@ -27,5 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "hostlist_expression"
   gem.add_runtime_dependency "oj"
   gem.add_runtime_dependency "winrm"
+  gem.add_runtime_dependency "inifile"
 
 end

--- a/lib/src/Rakefile
+++ b/lib/src/Rakefile
@@ -6,6 +6,7 @@ require 'ansible_spec'
 properties = AnsibleSpec.get_properties
 # {"name"=>"Ansible-Sample-TDD", "hosts"=>["192.168.0.103","192.168.0.103"], "user"=>"root", "roles"=>["nginx", "mariadb"]}
 # {"name"=>"Ansible-Sample-TDD", "hosts"=>[{"name" => "192.168.0.103:22","uri"=>"192.168.0.103","port"=>22, "private_key"=> "~/.ssh/id_rsa"}], "user"=>"root", "roles"=>["nginx", "mariadb"]}
+cfg = AnsibleSpec::AnsibleCfg.new
 
 desc "Run serverspec to all test"
 task :all => "serverspec:all"
@@ -36,7 +37,7 @@ namespace :serverspec do
           deps = AnsibleSpec.load_dependencies(role)
           roles += deps
         end
-        t.pattern = 'roles/{' + roles.join(',') + '}/spec/*_spec.rb'
+        t.pattern = '{' + cfg.roles_path.join(',') + '}/{' + roles.join(',') + '}/spec/*_spec.rb'
       end
     end
   end

--- a/spec/load_ansible_cfg_spec.rb
+++ b/spec/load_ansible_cfg_spec.rb
@@ -1,0 +1,91 @@
+# coding: utf-8
+require 'fileutils'
+require 'ansible_spec'
+
+def create_file(name,content)
+  dir = File.dirname(name)
+  unless File.directory?(dir)
+    FileUtils.mkdir_p(dir)
+  end
+  File.open(name, 'w') do |f|
+    f.puts content
+  end
+end
+
+describe "load_ansible_cfg" do
+  context 'with ANSIBLE_CFG set' do
+    tmp_cfg = 'tmp_ansible.cfg'
+    saved_env = nil
+
+    before do
+      content = <<'EOF'
+[ansible_spec1]
+roles_path = roles_path1:roles_path2
+EOF
+      create_file(tmp_cfg,content)
+      saved_env = ENV['ANSIBLE_CFG']
+      ENV['ANSIBLE_CFG'] = tmp_cfg
+      @res = AnsibleSpec::AnsibleCfg.load_ansible_cfg()
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    it 'res has section' do
+      expect(@res).to include('ansible_spec1')
+    end
+
+    it 'section has roles_path' do
+      expect(@res['ansible_spec1']).to include('roles_path')
+    end
+
+    it 'roles_path is set' do
+      expect(@res['ansible_spec1']['roles_path']).to eq('roles_path1:roles_path2')
+    end
+
+    after do
+      File.delete(tmp_cfg)
+      ENV['ANSIBLE_CFG'] = saved_env
+    end
+  end
+end
+
+describe "AnsibleCfg" do
+  context 'with ANSIBLE_CFG set' do
+    tmp_cfg = 'tmp_ansible.cfg'
+    saved_env = nil
+
+    before do
+      content = <<'EOF'
+[ansible_spec1]
+roles_path = roles_path1:roles_path2
+EOF
+      create_file(tmp_cfg,content)
+      saved_env = ENV['ANSIBLE_CFG']
+      ENV['ANSIBLE_CFG'] = tmp_cfg
+      @cfg = AnsibleSpec::AnsibleCfg.new
+    end
+
+    it 'elem handles unknown sections' do
+      expect(@cfg.get('doesnot', 'exist')).to be_nil
+    end
+
+    it 'elem handles unknown keys' do
+      expect(@cfg.get('ansible_spec1', 'doesnot_exist')).to be_nil
+    end
+
+    it 'elem handles known eys ' do
+      expect(@cfg.get('ansible_spec1', 'roles_path')).to be_truthy
+    end
+
+    it 'cfg has a roles path' do
+       expect(@cfg.roles_path).to be_truthy
+     end
+
+    after do
+      File.delete(tmp_cfg)
+      ENV['ANSIBLE_CFG'] = saved_env
+    end
+  end
+end


### PR DESCRIPTION
This allows us to find specs that are not under ./roles. Setting

  [defaults]
  roles_path = moreroles

in ansible.cfg leads to this pattern for rspec:

  --pattern \{moreroles,roles\}/\{role1,role2\}/spec/\*_spec.rb

Introduce a AnsibleCfg class for that. This currently only holds
roles_path but can be extended to handle e.g. remote_user as well.

Closes #86