### PR TITLE
#89 use ENV['SSH_CONFIG_FILE'] or ssh_args at ansible_cfg

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -300,6 +300,33 @@ module AnsibleSpec
     return hash_behaviour
   end
 
+  # param: none
+  # return: file path
+  def self.get_ssh_config_file()
+    ssh_config_file = nil
+
+    cfg = AnsibleSpec::AnsibleCfg.new
+    ssh_args = cfg.get('ssh_connection', 'ssh_args')
+    if ssh_args
+      array = ssh_args.split(" ")
+      if array.index("-F") && array[array.index("-F") + 1]
+        ssh_config_file = array[array.index("-F") + 1]
+      end
+    end
+
+    if ENV["SSH_CONFIG_FILE"]
+      ssh_config_file = ENV["SSH_CONFIG_FILE"]
+    end
+
+    return nil if ssh_config_file.nil?
+
+    if File.exist?(ssh_config_file)
+      return ssh_config_file
+    else
+      return nil
+    end
+  end
+
   # param: hash
   # param: variable file
   # param: flag to extention

--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -11,6 +11,7 @@ hosts = ENV["TARGET_HOSTS"]
 
 group_idx = ENV['TARGET_GROUP_INDEX'].to_i
 vars = AnsibleSpec.get_variables(host, group_idx,hosts)
+ssh_config_file = AnsibleSpec.get_ssh_config_file
 set_property vars
 
 connection = ENV['TARGET_CONNECTION']
@@ -32,7 +33,11 @@ if connection != 'winrm'
     set :sudo_password, ENV['SUDO_PASSWORD']
   end
 
-  options = Net::SSH::Config.for(host)
+  unless ssh_config_file
+    options = Net::SSH::Config.for(host)
+  else
+    options = Net::SSH::Config.for(host,files=[ssh_config_file])
+  end
 
   options[:user] ||= ENV['TARGET_USER']
   options[:port] ||= ENV['TARGET_PORT']

--- a/spec/load_ansible_cfg_ssh_spec.rb
+++ b/spec/load_ansible_cfg_ssh_spec.rb
@@ -1,0 +1,152 @@
+# coding: utf-8
+require 'fileutils'
+require 'ansible_spec'
+
+def create_file(name,content)
+  dir = File.dirname(name)
+  unless File.directory?(dir)
+    FileUtils.mkdir_p(dir)
+  end
+  File.open(name, 'w') do |f|
+    f.puts content
+  end
+end
+
+describe "get_ssh_config_file" do
+  context 'with SSH_CONFIG_FILE set' do
+    tmp_cfg = 'tmp_ansible.cfg'
+    tmp_ssh_cfg = 'hoge_config'
+    tmp_env_ssh_cfg = 'env_config'
+    saved_env = nil
+
+    before do
+      content = <<'EOF'
+[ssh_connection]
+ssh_args = -F hoge_config
+EOF
+      content_ssh = <<'EOF'
+EOF
+      create_file(tmp_cfg,content)
+      create_file(tmp_env_ssh_cfg,content_ssh)
+      saved_env = ENV['SSH_CONFIG_FILE']
+      ENV['SSH_CONFIG_FILE'] = tmp_env_ssh_cfg
+      @res = AnsibleSpec.get_ssh_config_file()
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(String)).to be_truthy
+    end
+
+    it 'res has section' do
+      expect(@res).to eq('env_config')
+    end
+
+    after do
+      File.delete(tmp_cfg)
+      File.delete(tmp_env_ssh_cfg)
+      ENV['SSH_CONFIG_FILE'] = saved_env
+    end
+  end
+
+  context 'without SSH_CONFIG_FILE set' do
+    tmp_cfg = 'tmp_ansible.cfg'
+    tmp_ssh_cfg = 'hoge_config'
+    saved_env = nil
+    saved_env_ansible = nil
+
+    before do
+      content = <<'EOF'
+[ssh_connection]
+ssh_args = -F hoge_config
+EOF
+      content_ssh = <<'EOF'
+EOF
+      create_file(tmp_cfg,content)
+      saved_env_ansible = ENV['ANSIBLE_CFG']
+      ENV['ANSIBLE_CFG'] = tmp_cfg
+
+      create_file(tmp_ssh_cfg,content_ssh)
+
+      saved_env = ENV['SSH_CONFIG_FILE']
+      ENV['SSH_CONFIG_FILE'] = nil
+      @res = AnsibleSpec.get_ssh_config_file()
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(String)).to be_truthy
+    end
+
+    it 'res has section' do
+      expect(@res).to eq('hoge_config')
+    end
+
+    after do
+      File.delete(tmp_cfg)
+      File.delete(tmp_ssh_cfg)
+      ENV['ANSIBLE_CFG'] = saved_env_ansible
+      ENV['SSH_CONFIG_FILE'] = saved_env
+    end
+  end
+
+  context 'not set -F <file> at ANSIBLE_CFG' do
+    tmp_cfg = 'tmp_ansible.cfg'
+    saved_env = nil
+    saved_env_ansible = nil
+
+    before do
+      content = <<'EOF'
+[ssh_connection]
+ssh_args = -o ControlMaster=auto
+EOF
+      content_ssh = <<'EOF'
+EOF
+      create_file(tmp_cfg,content)
+      saved_env_ansible = ENV['ANSIBLE_CFG']
+      ENV['ANSIBLE_CFG'] = tmp_cfg
+
+      saved_env = ENV['SSH_CONFIG_FILE']
+      ENV['SSH_CONFIG_FILE'] = nil
+      @res = AnsibleSpec.get_ssh_config_file()
+    end
+
+    it 'res has section' do
+      expect(@res).to eq nil
+    end
+
+    after do
+      File.delete(tmp_cfg)
+      ENV['SSH_CONFIG_FILE'] = saved_env
+      ENV['ANSIBLE_CFG'] = saved_env_ansible
+    end
+  end
+
+  context 'not exist SSH_CONFIG_FILE' do
+    tmp_cfg = 'tmp_ansible.cfg'
+    saved_env = nil
+    saved_env_ansible = nil
+
+    before do
+      content = <<'EOF'
+[ssh_connection]
+ssh_args = -F hoge_config
+EOF
+      create_file(tmp_cfg,content)
+      saved_env = ENV['SSH_CONFIG_FILE']
+      ENV['SSH_CONFIG_FILE'] = nil
+      saved_env_ansible = ENV['ANSIBLE_CFG']
+      ENV['ANSIBLE_CFG'] = tmp_cfg
+      @res = AnsibleSpec.get_ssh_config_file()
+    end
+
+    it 'res has section' do
+      expect(@res).to eq nil
+    end
+
+    after do
+      File.delete(tmp_cfg)
+      ENV['SSH_CONFIG_FILE'] = saved_env
+      ENV['ANSIBLE_CFG'] = saved_env_ansible
+    end
+  end
+end
+


### PR DESCRIPTION
links #89 

use the SSH setting in the following order.
(次の順でSSH設定を使用する。)

1. ENV['SSH_CONFIG_FILE'] //high priority
1. ssh_args( -F "filename") in  [ssh_connection] section of ansible.cfg //low priority  
ansible.cfg内の[ssh_connection]セクション ssh_args内の-F で指定したファイル

To read ansible.cfg, use Merge with #91
(なお、ansible.cfgの読み込みは #91でMergeしたものを使用する。)