### PR TITLE
Handle roles_path for role dependencies as well

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -196,12 +196,12 @@ module AnsibleSpec
 
   # param: role
   # return: ["role1", "role2"]
-  def self.load_dependencies(role)
+  def self.load_dependencies(role, rolepath='roles')
     role_queue = [role]
     deps = []
     until role_queue.empty?
       role = role_queue.pop()
-      path = File.join("./", "roles", role, "meta", "main.yml")
+      path = File.join(rolepath, role, "meta", "main.yml")
 
       if File.exist?(path)
         dependencies = YAML.load_file(path).fetch("dependencies", [])

--- a/lib/src/Rakefile
+++ b/lib/src/Rakefile
@@ -34,8 +34,13 @@ namespace :serverspec do
 
         roles = property["roles"]
         for role in property["roles"]
-          deps = AnsibleSpec.load_dependencies(role)
-          roles += deps
+          for rolepath in cfg.roles_path
+            deps = AnsibleSpec.load_dependencies(role, rolepath)
+            if deps != []
+              roles += deps
+              break
+            end
+          end
         end
         t.pattern = '{' + cfg.roles_path.join(',') + '}/{' + roles.join(',') + '}/spec/*_spec.rb'
       end

--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -87,3 +87,26 @@ EOF
     File.delete(tmp_webapp_meta)
   end
 end
+
+describe "load_dependencies from alternative dir" do
+  tmp_webapp_meta = 'more_roles/webapp/meta/main.yml'
+
+  webapp_meta_content = <<'EOF'
+---
+dependencies:
+ - foo
+EOF
+
+  before do
+    create_file(tmp_webapp_meta, webapp_meta_content)
+    @deps = AnsibleSpec.load_dependencies("webapp", "more_roles")
+  end
+
+  it 'should correctly resolve deps in additional role dirs' do
+    expect(@deps).to eq ["foo"]
+  end
+
+  after do
+    File.delete(tmp_webapp_meta)
+  end
+end


### PR DESCRIPTION
While roles in non standard roles paths referenced from playbooks are
handled fine since d5b97d7a3bd5a14d127495f7cd93aba0c7524b40 we did not
yet handle them when being dependencies of other roles.

Let load_dependencies default to 'roles/' to not break existing
Rakefiles