### PR TITLE
Unbreak 'serverspec:all' if groups with no hosts exist

### DIFF
--- a/lib/src/Rakefile
+++ b/lib/src/Rakefile
@@ -12,8 +12,8 @@ desc "Run serverspec to all test"
 task :all => "serverspec:all"
 
 namespace :serverspec do
-  task :all => properties.map {|v| 'serverspec:' + v["name"] }
   properties = properties.compact.reject{|e| e["hosts"].length == 0}
+  task :all => properties.map {|v| 'serverspec:' + v["name"] }
   properties.each_with_index.map do |property, index|
     property["hosts"].each do |host|
       desc "Run serverspec for #{property["name"]}"


### PR DESCRIPTION
The code already filters out groups with no hosts but does so after
building the taks which leads to errors like

    bundle exec rake --rules  'serverspec:all'
    no hosts matched for Empty Group
    rake aborted!
    Don't know how to build task 'serverspec:Empty Group'

so just swap the two lines.