### PR TITLE
fix sudo directive for after Ansible 1.9

### DIFF
--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -23,15 +23,15 @@ when 'ssh'
 #
   set :backend, :ssh
 
-  if ENV['ASK_SUDO_PASSWORD']
+  if ENV['ASK_BECOME_PASSWORD']
     begin
       require 'highline/import'
     rescue LoadError
       fail "highline is not available. Try installing it."
     end
-    set :sudo_password, ask("Enter sudo password: ") { |q| q.echo = false }
+    set :become_password, ask("Enter become password: ") { |q| q.echo = false }
   else
-    set :sudo_password, ENV['SUDO_PASSWORD']
+    set :become_password, ENV['BECOME_PASSWORD']
   end
 
   unless ssh_config_file
@@ -47,8 +47,8 @@ when 'ssh'
   set :host,        options[:host_name] || host
   set :ssh_options, options
 
-  # Disable sudo
-  # set :disable_sudo, true
+  # Disable become
+  # set :become, false
 
 
   # Set environment variables


### PR DESCRIPTION
Hi! 
I found DEPRECATION WARNING when I use default spec_helper.rb .
spec_helper.rb has 'sudo directive', it's Ansible old directive .
I think we should use 'become directive' for after Ansible version 1.9 .

* DEPRECATION WARNING as below

```
$ ansible-playbook main.yml 
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make sure become_method is 'sudo' (default).
This feature will be removed in a future release. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

* Ansible reference link

http://docs.ansible.com/ansible/latest/become.html
