### PR TITLE
Make ENV variables override SSH config file options

### DIFF
--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -34,15 +34,16 @@ when 'ssh'
     set :become_password, ENV['BECOME_PASSWORD']
   end
 
-  unless ssh_config_file
-    options = Net::SSH::Config.for(host)
-  else
-    options = Net::SSH::Config.for(host,files=[ssh_config_file])
-  end
+  options = Net::SSH::Config.for(host)
 
   options[:user] = ENV['TARGET_USER'] || options[:user]
   options[:port] = ENV['TARGET_PORT'] || options[:port]
   options[:keys] = ENV['TARGET_PRIVATE_KEY'] || options[:keys]
+
+  if ssh_config_file
+    from_config_file = Net::SSH::Config.for(host,files=[ssh_config_file])
+    options.merge!(from_config_file)
+  end
 
   set :host,        options[:host_name] || host
   set :ssh_options, options

--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -40,9 +40,9 @@ when 'ssh'
     options = Net::SSH::Config.for(host,files=[ssh_config_file])
   end
 
-  options[:user] ||= ENV['TARGET_USER']
-  options[:port] ||= ENV['TARGET_PORT']
-  options[:keys] ||= ENV['TARGET_PRIVATE_KEY']
+  options[:user] = ENV['TARGET_USER']
+  options[:port] = ENV['TARGET_PORT']
+  options[:keys] = ENV['TARGET_PRIVATE_KEY']
 
   set :host,        options[:host_name] || host
   set :ssh_options, options

--- a/lib/src/spec/spec_helper.rb
+++ b/lib/src/spec/spec_helper.rb
@@ -40,9 +40,9 @@ when 'ssh'
     options = Net::SSH::Config.for(host,files=[ssh_config_file])
   end
 
-  options[:user] = ENV['TARGET_USER']
-  options[:port] = ENV['TARGET_PORT']
-  options[:keys] = ENV['TARGET_PRIVATE_KEY']
+  options[:user] = ENV['TARGET_USER'] || options[:user]
+  options[:port] = ENV['TARGET_PORT'] || options[:port]
+  options[:keys] = ENV['TARGET_PRIVATE_KEY'] || options[:keys]
 
   set :host,        options[:host_name] || host
   set :ssh_options, options


### PR DESCRIPTION
My SSH config file defaults to "ec2-user", and I noticed that ansiblespec was not overriding the SSH user when connecting to Ubuntu instances.

Also, this replicates how it is being done for winrm connections
https://github.com/volanja/ansible_spec/blob/32d01104148f8bed5a7ef4c205ff14c6a425d340/lib/src/spec/spec_helper.rb#L66-L68