### PR TITLE
Support import_playbook

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -234,6 +234,10 @@ module AnsibleSpec
           YAML.load_file(site["include"]).each { |site|
             properties.push site
           }
+      elsif site.has_key?("import_playbook")
+          YAML.load_file(site["import_playbook"]).each { |site|
+            properties.push site
+          }
       else
         properties.push site
       end

--- a/spec/load_ansible_spec.rb
+++ b/spec/load_ansible_spec.rb
@@ -570,12 +570,13 @@ EOF
     end
   end
 
-  context '正常系(include)' do
-    require 'yaml'
-    tmp_pb = 'site.yml'
-    tmp_inc = 'nginx.yml'
-    before do
-      content_pb = <<'EOF'
+  %w[include import_playbook].each do |action|
+    context "正常系(#{action})" do
+      require 'yaml'
+      tmp_pb = 'site.yml'
+      tmp_inc = 'nginx.yml'
+      before do
+        content_pb = <<'EOF'
 - name: Ansible-Sample-TDD
   hosts: server
   user: root
@@ -583,9 +584,9 @@ EOF
     - mariadb
 - include: nginx.yml
 EOF
-      create_file(tmp_pb,content_pb)
+        create_file(tmp_pb,content_pb)
 
-      content_inc = <<'EOF'
+        content_inc = <<'EOF'
 - name: Ansible-Nginx
   hosts: web
   user: nginx
@@ -598,87 +599,88 @@ EOF
   roles:
    - nginx-proxy
 EOF
-      create_file(tmp_inc,content_inc)
+        create_file(tmp_inc,content_inc)
 
-      @res = AnsibleSpec.load_playbook(tmp_pb)
-    end
+        @res = AnsibleSpec.load_playbook(tmp_pb)
+      end
 
-    it 'res is array' do
-      expect(@res.instance_of?(Array)).to be_truthy
-    end
+      it 'res is array' do
+        expect(@res.instance_of?(Array)).to be_truthy
+      end
 
-    it 'res has three groups' do
-      expect(@res.length).to eq 3
-    end
+      it 'res has three groups' do
+        expect(@res.length).to eq 3
+      end
 
 
-    it 'res is hash' do
-      expect(@res[0].instance_of?(Hash)).to be_truthy
-    end
+      it 'res is hash' do
+        expect(@res[0].instance_of?(Hash)).to be_truthy
+      end
 
-    it 'check 1 group' do
-      expect(@res[0].length).to eq 4
-    end
+      it 'check 1 group' do
+        expect(@res[0].length).to eq 4
+      end
 
-    it 'exist name' do
-      expect(@res[0].key?('name')).to be_truthy
-      expect(@res[0]['name']).to eq 'Ansible-Sample-TDD'
-    end
+      it 'exist name' do
+        expect(@res[0].key?('name')).to be_truthy
+        expect(@res[0]['name']).to eq 'Ansible-Sample-TDD'
+      end
 
-    it 'exist hosts' do
-      expect(@res[0].key?('hosts')).to be_truthy
-      expect(@res[0]['hosts']).to eq 'server'
-    end
+      it 'exist hosts' do
+        expect(@res[0].key?('hosts')).to be_truthy
+        expect(@res[0]['hosts']).to eq 'server'
+      end
 
-    it 'exist user' do
-      expect(@res[0].key?('user')).to be_truthy
-      expect(@res[0]['user']).to eq 'root'
-    end
+      it 'exist user' do
+        expect(@res[0].key?('user')).to be_truthy
+        expect(@res[0]['user']).to eq 'root'
+      end
 
-    it 'exist roles' do
-      expect(@res[0].key?('roles')).to be_truthy
-      expect(@res[0]['roles'].instance_of?(Array)).to be_truthy
-      expect(@res[0]['roles'][0]).to eq 'mariadb'
-    end
+      it 'exist roles' do
+        expect(@res[0].key?('roles')).to be_truthy
+        expect(@res[0]['roles'].instance_of?(Array)).to be_truthy
+        expect(@res[0]['roles'][0]).to eq 'mariadb'
+      end
 
-    # - include: nginx.yml
-    it 'res is hash' do
-      expect(@res[1].instance_of?(Hash)).to be_truthy
-    end
+      # - include: nginx.yml
+      it 'res is hash' do
+        expect(@res[1].instance_of?(Hash)).to be_truthy
+      end
 
-    it 'check 1 group' do
-      expect(@res[1].length).to eq 4
-    end
+      it 'check 1 group' do
+        expect(@res[1].length).to eq 4
+      end
 
-    it 'exist name' do
-      expect(@res[1].key?('name')).to be_truthy
-      expect(@res[1]['name']).to eq 'Ansible-Nginx'
-    end
+      it 'exist name' do
+        expect(@res[1].key?('name')).to be_truthy
+        expect(@res[1]['name']).to eq 'Ansible-Nginx'
+      end
 
-    it 'exist hosts' do
-      expect(@res[1].key?('hosts')).to be_truthy
-      expect(@res[1]['hosts']).to eq 'web'
-    end
+      it 'exist hosts' do
+        expect(@res[1].key?('hosts')).to be_truthy
+        expect(@res[1]['hosts']).to eq 'web'
+      end
 
-    it 'exist user' do
-      expect(@res[1].key?('user')).to be_truthy
-      expect(@res[1]['user']).to eq 'nginx'
-    end
+      it 'exist user' do
+        expect(@res[1].key?('user')).to be_truthy
+        expect(@res[1]['user']).to eq 'nginx'
+      end
 
-    it 'exist roles' do
-      expect(@res[1].key?('roles')).to be_truthy
-      expect(@res[1]['roles'].instance_of?(Array)).to be_truthy
-      expect(@res[1]['roles'][0]).to eq 'nginx'
-    end
+      it 'exist roles' do
+        expect(@res[1].key?('roles')).to be_truthy
+        expect(@res[1]['roles'].instance_of?(Array)).to be_truthy
+        expect(@res[1]['roles'][0]).to eq 'nginx'
+      end
 
-    it 'exist name' do
-      expect(@res[2].key?('name')).to be_truthy
-      expect(@res[2]['name']).to eq 'Ansible-Nginx2'
-    end
+      it 'exist name' do
+        expect(@res[2].key?('name')).to be_truthy
+        expect(@res[2]['name']).to eq 'Ansible-Nginx2'
+      end
 
-    after do
-      File.delete(tmp_pb)
-      File.delete(tmp_inc)
+      after do
+        File.delete(tmp_pb)
+        File.delete(tmp_inc)
+      end
     end
   end
 


### PR DESCRIPTION
Hello.
Thank you for your project. I'd like to support import_playbook.

Here's a warning.
```sh
[DEPRECATION WARNING]: 'include' for playbook includes. You should use 'import_playbook' instead. This feature will be removed in version 2.8.
```
* Docs
http://docs.ansible.com/ansible/latest/include_module.html
http://docs.ansible.com/ansible/latest/import_playbook_module.html