### PR TITLE
Incorporate group parent child relationships into variable assignment hierarchy

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -8,9 +8,15 @@ require 'ansible_spec/vendor/hash'
 
 module AnsibleSpec
   # param: inventory file of Ansible
+  # param: return_type 'groups' or 'groups_parent_child_relationships'
   # return: Hash {"group" => ["192.168.0.1","192.168.0.2"]}
   # return: Hash {"group" => [{"name" => "192.168.0.1","uri" => "192.168.0.1", "port" => 22},...]}
-  def self.load_targets(file)
+  # return: Hash {"pg" => ["server", "databases"]}
+  def self.load_targets(file, return_type = 'groups')
+    if not ['groups', 'groups_parent_child_relationships'].include?(return_type)
+      raise ArgumentError, "Variable return_type must be value 'groups' or 'groups_parent_child_relationships'"
+    end
+
     if File.executable?(file)
       return get_dynamic_inventory(file)
     end
@@ -67,8 +73,12 @@ module AnsibleSpec
 
     # parse children [group:children]
     search = Regexp.new(":children".to_s)
+    groups_parent_child_relationships = Hash.new
     groups.keys.each{|k|
       unless (k =~ search).nil?
+        # get parent child relationships
+        k_parent = k.gsub(search,'')
+        groups_parent_child_relationships["#{k_parent}"] = groups["#{k}"]
         # get group parent & merge parent
         groups.merge!(get_parent(groups,search,k))
         # delete group children
@@ -77,7 +87,16 @@ module AnsibleSpec
         end
       end
     }
-    return groups
+
+    if return_type == 'groups'
+      return_value = groups
+    elsif return_type == 'groups_parent_child_relationships'
+      return_value = groups_parent_child_relationships
+    else
+      return_value = groups
+    end
+
+    return return_value
   end
 
   # param  hash   {"server"=>["192.168.0.103"], "databases"=>["192.168.0.104"], "pg:children"=>["server", "databases"]}
@@ -488,7 +507,21 @@ module AnsibleSpec
 
     # each group vars
     if p[group_idx].has_key?('group')
-      vars = load_vars_file(vars ,"#{vars_dirs_path}group_vars/#{p[group_idx]['group']}", true)
+      # get groups parent child relationships
+      playbook, inventoryfile = load_ansiblespec
+      groups_rels = load_targets(inventoryfile, return_type='groups_parent_child_relationships')
+      # get parental lineage
+      g = p[group_idx]['group']
+      groups_stack = Array.new
+      groups_stack << g
+      groups_rels.keys.each{|k|
+        groups_stack << k if (groups_rels[k].include?(g))
+      }
+      # get vars from parents groups then child group
+      groups_parents_then_child = groups_stack.reverse.flatten
+      groups_parents_then_child.each{|group|
+        vars = load_vars_file(vars ,"#{vars_dirs_path}group_vars/#{group}", true)
+      }
     end
 
     # each host vars

--- a/spec/case/get_variable/group_each_vars_parent_child/group_vars/all.yml
+++ b/spec/case/get_variable/group_each_vars_parent_child/group_vars/all.yml
@@ -1,0 +1,6 @@
+---
+role_var:  "group all"
+site_var:  "group all"
+host_var:  "group all"
+group_var: "group all"
+group_all_var: "group all"

--- a/spec/case/get_variable/group_each_vars_parent_child/group_vars/group1/vars
+++ b/spec/case/get_variable/group_each_vars_parent_child/group_vars/group1/vars
@@ -1,0 +1,4 @@
+role_var:  "group1"
+site_var:  "group1"
+host_var:  "group1"
+group_var: 'group1'

--- a/spec/case/get_variable/group_each_vars_parent_child/group_vars/group2/vars
+++ b/spec/case/get_variable/group_each_vars_parent_child/group_vars/group2/vars
@@ -1,0 +1,4 @@
+role_var:  "group2"
+site_var:  "group2"
+host_var:  "group2"
+group_var: 'group2'

--- a/spec/case/get_variable/group_each_vars_parent_child/group_vars/parentgroup/vars
+++ b/spec/case/get_variable/group_each_vars_parent_child/group_vars/parentgroup/vars
@@ -1,0 +1,5 @@
+role_var:  "parentgroup"
+site_var:  "parentgroup"
+host_var:  "parentgroup"
+group_var: 'parentgroup'
+group_var_parent: 'parentgroup'

--- a/spec/case/get_variable/group_each_vars_parent_child/hosts
+++ b/spec/case/get_variable/group_each_vars_parent_child/hosts
@@ -1,0 +1,13 @@
+[group1]
+192.168.1.1
+
+[group2]
+192.168.1.2
+
+[all]
+192.168.1.1
+192.168.1.2
+
+[parentgroup:children]
+group1
+group2

--- a/spec/case/get_variable/group_each_vars_parent_child/site.yml
+++ b/spec/case/get_variable/group_each_vars_parent_child/site.yml
@@ -1,0 +1,6 @@
+- name: group1
+  hosts: group1
+  connection: local
+  roles:
+  - test
+  - test/nested

--- a/spec/case/get_variable/group_each_vars_parent_child/site1.yml
+++ b/spec/case/get_variable/group_each_vars_parent_child/site1.yml
@@ -1,0 +1,6 @@
+- name: group1
+  hosts: group1
+  connection: local
+  roles:
+  - test
+  - test/nested

--- a/spec/case/get_variable/group_each_vars_parent_child/site2.yml
+++ b/spec/case/get_variable/group_each_vars_parent_child/site2.yml
@@ -1,0 +1,6 @@
+- name: group2
+  hosts: group2
+  connection: local
+  roles:
+  - test
+  - test/nested

--- a/spec/case/get_variable/group_each_vars_parent_child/site3.yml
+++ b/spec/case/get_variable/group_each_vars_parent_child/site3.yml
@@ -1,0 +1,6 @@
+- name: parentgroup
+  hosts: parentgroup
+  connection: local
+  roles:
+  - test
+  - test/nested

--- a/spec/get_variable_spec.rb
+++ b/spec/get_variable_spec.rb
@@ -254,6 +254,114 @@ describe "get_variablesの実行" do
     end
   end
 
+  context 'Correct operation : group vars for group1 hosts ' do
+    before do
+      @current_dir = Dir.pwd()
+      Dir.chdir('spec/case/get_variable/group_each_vars_parent_child/')
+      ENV["PLAYBOOK"] = 'site1.yml'
+      ENV["INVENTORY"] = 'hosts'
+      ENV["VARS_DIRS_PATH"] = ''
+      @res = AnsibleSpec.get_variables("192.168.1.1", 0, "group1")
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    it 'exist 6 pair in Hash' do
+      expect(@res.length).to eq 6
+    end
+
+    it 'exist each pair' do
+      expect(@res).to include( {"role_var"=>"group1"},
+                               {"site_var"=>"group1"},
+                               {"host_var"=>"group1"},
+                               {"group_var"=>"group1"},
+                               {"group_var_parent"=>"parentgroup"},
+                               {"group_all_var"=>"group all"}
+                             )
+    end
+
+    after do
+      ENV.delete('PLAYBOOK')
+      ENV.delete('INVENTORY')
+      ENV.delete('VARS_DIRS_PATH')
+      Dir.chdir(@current_dir)
+    end
+  end
+
+  context 'Correct operation : group vars for group2 hosts ' do
+    before do
+      @current_dir = Dir.pwd()
+      Dir.chdir('spec/case/get_variable/group_each_vars_parent_child/')
+      ENV["PLAYBOOK"] = 'site2.yml'
+      ENV["INVENTORY"] = 'hosts'
+      ENV["VARS_DIRS_PATH"] = ''
+      @res = AnsibleSpec.get_variables("192.168.1.2", 0, "group2")
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    it 'exist 6 pair in Hash' do
+      expect(@res.length).to eq 6
+    end
+
+    it 'exist each pair' do
+      expect(@res).to include( {"role_var"=>"group2"},
+                               {"site_var"=>"group2"},
+                               {"host_var"=>"group2"},
+                               {"group_var"=>"group2"},
+                               {"group_var_parent"=>"parentgroup"},
+                               {"group_all_var"=>"group all"}
+                             )
+    end
+
+    after do
+      ENV.delete('PLAYBOOK')
+      ENV.delete('INVENTORY')
+      ENV.delete('VARS_DIRS_PATH')
+      Dir.chdir(@current_dir)
+    end
+  end
+
+  context 'Correct operation : group vars for parentgroup hosts ' do
+    before do
+      @current_dir = Dir.pwd()
+      Dir.chdir('spec/case/get_variable/group_each_vars_parent_child/')
+      ENV["PLAYBOOK"] = 'site3.yml'
+      ENV["INVENTORY"] = 'hosts'
+      ENV["VARS_DIRS_PATH"] = ''
+      @res = AnsibleSpec.get_variables("192.168.1.1", 0, "parentgroup")
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    it 'exist 6 pair in Hash' do
+      expect(@res.length).to eq 6
+    end
+
+    it 'exist each pair' do
+      expect(@res).to include( {"role_var"=>"parentgroup"},
+                               {"site_var"=>"parentgroup"},
+                               {"host_var"=>"parentgroup"},
+                               {"group_var"=>"parentgroup"},
+                               {"group_var_parent"=>"parentgroup"},
+                               {"group_all_var"=>"group all"}
+                             )
+    end
+
+    after do
+      ENV.delete('PLAYBOOK')
+      ENV.delete('INVENTORY')
+      ENV.delete('VARS_DIRS_PATH')
+      Dir.chdir(@current_dir)
+    end
+  end
+
 end
 
 describe "get_hash_behaviourの実行" do

--- a/spec/load_ansible_spec.rb
+++ b/spec/load_ansible_spec.rb
@@ -400,6 +400,43 @@ EOF
     end
   end
 
+  context 'load_targets:Return groups parent child relationships' do
+    tmp_hosts = 'hosts'
+    before do
+      content_h = <<'EOF'
+[server]
+192.168.0.103
+192.168.0.104 ansible_ssh_port=22
+
+[databases]
+192.168.0.105
+192.168.0.106 ansible_ssh_port=5555
+
+[pg:children]
+server
+databases
+EOF
+      create_file(tmp_hosts,content_h)
+      @res = AnsibleSpec.load_targets(tmp_hosts, return_type='groups_parent_child_relationships')
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    it 'exist 1 group parent child relationship in Hash' do
+      expect(@res.length).to eq 1
+    end
+
+    it 'exist each pair' do
+      expect(@res).to include({"pg"=>["server", "databases"]})
+    end
+
+    after do
+      File.delete(tmp_hosts)
+    end
+  end
+
 end
 
 describe "load_playbookの実行" do

--- a/spec/load_ansible_spec.rb
+++ b/spec/load_ansible_spec.rb
@@ -400,7 +400,193 @@ EOF
     end
   end
 
-  context 'load_targets:Return groups parent child relationships' do
+  context 'load_targets:Test invalid return_type' do
+    tmp_hosts = 'hosts'
+    content_excpetion_msg = "Variable return_type must be value 'groups' or 'groups_parent_child_relationships'"
+    before do
+      content_h = <<'EOF'
+[server]
+192.168.0.103
+192.168.0.104 ansible_ssh_port=22
+
+[databases]
+192.168.0.105
+192.168.0.106 ansible_ssh_port=5555
+
+[pg:children]
+server
+databases
+EOF
+      create_file(tmp_hosts,content_h)
+      begin
+        @res = AnsibleSpec.load_targets(tmp_hosts, return_type='some_invalid_option')
+      rescue ArgumentError => e
+        @res = e.message
+      end
+    end
+
+    it 'res is string' do
+      expect(@res.instance_of?(String)).to be_truthy
+    end
+
+    it 'exist 1 string' do
+      expect(@res.length).to eq content_excpetion_msg.length
+    end
+
+    it 'exist string' do
+      expect(@res).to include(content_excpetion_msg)
+    end
+
+    after do
+      File.delete(tmp_hosts)
+    end
+  end
+
+  context 'load_targets:Return groups; default return_type (="groups")' do
+    tmp_hosts = 'hosts'
+    before do
+      content_h = <<'EOF'
+[server]
+192.168.0.103
+192.168.0.104 ansible_ssh_port=22
+
+[databases]
+192.168.0.105
+192.168.0.106 ansible_ssh_port=5555
+
+[pg:children]
+server
+databases
+EOF
+      create_file(tmp_hosts,content_h)
+      @res = AnsibleSpec.load_targets(tmp_hosts)
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    it 'exist 1 group' do
+      expect(@res.length).to eq 3
+    end
+
+    it 'exist group' do
+      expect(@res.key?('server')).to be_truthy
+      expect(@res.key?('databases')).to be_truthy
+      expect(@res.key?('pg')).to be_truthy
+      expect(@res.key?('pg:children')).not_to be_truthy
+    end
+
+    it 'pg 192.168.0.103' do
+      obj = @res['pg'][0]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj).to include({'name' => '192.168.0.103',
+                              'uri' => '192.168.0.103',
+                              'port' => 22})
+    end
+
+    it 'pg 192.168.0.104 ansible_ssh_port=22' do
+      obj = @res['pg'][1]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj['name']).to eq '192.168.0.104 ansible_ssh_port=22'
+      expect(obj['uri']).to eq '192.168.0.104'
+      expect(obj['port']).to eq 22
+    end
+
+    it 'pg 192.168.0.105' do
+      obj = @res['pg'][2]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj).to include({'name' => '192.168.0.105',
+                              'uri' => '192.168.0.105',
+                              'port' => 22})
+    end
+
+    it 'pg 192.168.0.106 ansible_ssh_port=5555' do
+      obj = @res['pg'][3]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj['name']).to eq '192.168.0.106 ansible_ssh_port=5555'
+      expect(obj['uri']).to eq '192.168.0.106'
+      expect(obj['port']).to eq 5555
+    end
+
+    after do
+      File.delete(tmp_hosts)
+    end
+  end
+
+  context 'load_targets:Return groups; return_type="groups"' do
+    tmp_hosts = 'hosts'
+    before do
+      content_h = <<'EOF'
+[server]
+192.168.0.103
+192.168.0.104 ansible_ssh_port=22
+
+[databases]
+192.168.0.105
+192.168.0.106 ansible_ssh_port=5555
+
+[pg:children]
+server
+databases
+EOF
+      create_file(tmp_hosts,content_h)
+      @res = AnsibleSpec.load_targets(tmp_hosts, return_type='groups')
+    end
+
+    it 'res is hash' do
+      expect(@res.instance_of?(Hash)).to be_truthy
+    end
+
+    it 'exist 1 group' do
+      expect(@res.length).to eq 3
+    end
+
+    it 'exist group' do
+      expect(@res.key?('server')).to be_truthy
+      expect(@res.key?('databases')).to be_truthy
+      expect(@res.key?('pg')).to be_truthy
+      expect(@res.key?('pg:children')).not_to be_truthy
+    end
+
+    it 'pg 192.168.0.103' do
+      obj = @res['pg'][0]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj).to include({'name' => '192.168.0.103',
+                              'uri' => '192.168.0.103',
+                              'port' => 22})
+    end
+
+    it 'pg 192.168.0.104 ansible_ssh_port=22' do
+      obj = @res['pg'][1]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj['name']).to eq '192.168.0.104 ansible_ssh_port=22'
+      expect(obj['uri']).to eq '192.168.0.104'
+      expect(obj['port']).to eq 22
+    end
+
+    it 'pg 192.168.0.105' do
+      obj = @res['pg'][2]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj).to include({'name' => '192.168.0.105',
+                              'uri' => '192.168.0.105',
+                              'port' => 22})
+    end
+
+    it 'pg 192.168.0.106 ansible_ssh_port=5555' do
+      obj = @res['pg'][3]
+      expect(obj.instance_of?(Hash)).to be_truthy
+      expect(obj['name']).to eq '192.168.0.106 ansible_ssh_port=5555'
+      expect(obj['uri']).to eq '192.168.0.106'
+      expect(obj['port']).to eq 5555
+    end
+
+    after do
+      File.delete(tmp_hosts)
+    end
+  end
+
+  context 'load_targets:Return groups parent child relationships; return_type="groups_parent_child_relationships"' do
     tmp_hosts = 'hosts'
     before do
       content_h = <<'EOF'


### PR DESCRIPTION
**TL;DR:**

Makes variables that are set at the parent group level available to child groups.

**Overview:**

The current code base does away with [parentgroup:children] groups in favour of converting the parent group into a group at the same level as its children. However, this dismisses the fact that parent-child relationships add a level of precedence to variable assignments for groups. This PR adds this logic to better align ansible_spec variable assignments with how this is done in Ansible.

**Example:**

hosts file:

![screenshot at 2018-08-22 05-25-50](https://user-images.githubusercontent.com/4683529/44458598-5a32f300-a5cc-11e8-8e74-c2fff1e8d2bb.png)

Makes variables set in ./group_vars/parentgroup/vars (or any files in the dir) available to hosts in the [group1] and [group2] groups.