### PR TITLE
Fix wrong index by empty group

### DIFF
--- a/lib/ansible_spec/load_ansible.rb
+++ b/lib/ansible_spec/load_ansible.rb
@@ -516,7 +516,7 @@ module AnsibleSpec
 
   def self.get_variables(host, group_idx, hosts=nil)
     vars = {}
-    p = self.get_properties
+    p = self.get_properties.compact.reject{|e| e["hosts"].length == 0}
 
     # roles default
     p[group_idx]['roles'].each do |role|


### PR DESCRIPTION
Fixed a problem that there is a gap between Index passed from Rakefile when empty group exists.



空の group があると Rakefile と実行で TARGET_GROUP_INDEX が一致せず、期待と異なる group_vars が読まれてしまうことに気付きました。その修正案です

repro
```
$ cat hosts
[group_a]
[group_b]
localhost.localdomain ansible_ssh_private_key_file=~/.ssh/id_rsa

$ grep "" inventories/example/group_vars/*
inventories/example/group_vars/group_a.yml:---
inventories/example/group_vars/group_a.yml:group_a_var: hoge
inventories/example/group_vars/group_b.yml:---
inventories/example/group_vars/group_b.yml:group_b_var: fuga

$ cat roles/role_b/spec/role_b_spec.rb
require 'spec_helper'
require 'json'
puts "--- role_b's spec ---"
puts JSON.pretty_generate property

$ bundle exec rake --tasks
rake all                    # Run serverspec to all test
rake serverspec:playbook_b  # Run serverspec for playbook_b

$ bundle exec rake serverspec:playbook_b
Run serverspec for playbook_b to {"name"=>"localhost.localdomain ansible_ssh_private_key_file=~/.ssh/id_rsa", "port"=>22, "connection"
=>"ssh", "uri"=>"localhost.localdomain", "private_key"=>"~/.ssh/id_rsa"}
/usr/local/rbenv/versions/2.6.4/bin/ruby -I/var/tmp/repo/vendor/bundle/ruby/2.6.0/gems/rspec-core-3.9.2/lib:/var/tmp/repo/vendor/bundl
e/ruby/2.6.0/gems/rspec-support-3.9.3/lib /var/tmp/repo/vendor/bundle/ruby/2.6.0/gems/rspec-core-3.9.2/exe/rspec --pattern \{roles\}/\
{role_b\}/spec/\*_spec.rb
--- role_b's spec ---
{
  "group_a_var": "hoge"
}
No examples found.
                                                                                                                                      Finished in 0.00027 seconds (files took 0.41523 seconds to load)
0 examples, 0 failures  
```